### PR TITLE
Included RANDOM and PREVRANDAO under banned opcodes as geth debug_tra…

### DIFF
--- a/packages/executor/customTracer.js
+++ b/packages/executor/customTracer.js
@@ -92,6 +92,8 @@ function tracer() {
         case 'ORIGIN':
         case 'COINBASE':
         case 'SELFDESTRUCT':
+        case 'RANDOM':
+        case 'PREVRANDAO':
         case 'CREATE':
         case 'CREATE2': {
           const to = this.addrs[log.getDepth() - 1];


### PR DESCRIPTION
…ceCall returns different data depending on the implementation since it is not a standard rpc, so it is wise to add all 3 of those opcodes to the ban list