### PR TITLE
Fix error parsing & introduce eip1559

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "stream": "true",
   "command": {
     "version": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "engines": {
     "node": ">=12.9.0"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "The API module of Etherspot bundler client",
   "author": "Etherspot",
   "homepage": "https://https://github.com/etherspot/skandha#readme",
@@ -35,12 +35,12 @@
     "class-transformer": "0.5.1",
     "class-validator": "0.14.0",
     "ethers": "5.7.2",
-    "executor": "^0.0.1",
+    "executor": "^0.0.5",
     "fastify": "4.14.1",
     "pino": "8.11.0",
     "pino-pretty": "10.0.0",
     "reflect-metadata": "0.1.13",
-    "types": "^0.0.1"
+    "types": "^0.0.5"
   },
   "devDependencies": {
     "@types/connect": "3.4.35"

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -95,7 +95,11 @@ export class ApiApp {
       const { method, params, jsonrpc, id } = req.body as any;
 
       // ADMIN METHODS
-      if (this.testingMode || req.ip === "localhost") {
+      if (
+        this.testingMode ||
+        req.ip === "localhost" ||
+        req.ip === "127.0.0.1"
+      ) {
         switch (method) {
           case BundlerRPCMethods.debug_bundler_setBundlingMode:
             result = await debugApi.setBundlingMode(params[0]);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "> TODO: description",
   "author": "zincoshine <psramanuj@gmail.com>",
   "homepage": "https://https://github.com/etherspot/skandha#readme",
@@ -31,13 +31,13 @@
     "url": "https://https://github.com/etherspot/skandha/issues"
   },
   "dependencies": {
-    "api": "^0.0.1",
-    "db": "^0.0.1",
-    "executor": "^0.0.1",
+    "api": "^0.0.5",
+    "db": "^0.0.5",
+    "executor": "^0.0.5",
     "find-up": "5.0.0",
     "got": "12.5.3",
     "js-yaml": "4.1.0",
-    "types": "^0.0.1",
+    "types": "^0.0.5",
     "yargs": "17.6.2"
   },
   "devDependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "db",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "The DB module of Etherspot bundler client",
   "author": "Etherspot",
   "homepage": "https://github.com/etherspot/etherspot-bundler#readme",
@@ -37,6 +37,6 @@
   "devDependencies": {
     "@types/rocksdb": "3.0.1",
     "prettier": "^2.8.4",
-    "types": "^0.0.1"
+    "types": "^0.0.5"
   }
 }

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "executor",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "The Relayer module of Etherspot bundler client",
   "author": "Etherspot",
   "homepage": "https://https://github.com/etherspot/skandha#readme",
@@ -33,7 +33,7 @@
   "dependencies": {
     "async-mutex": "0.4.0",
     "ethers": "5.7.2",
-    "params": "^0.0.1",
-    "types": "^0.0.1"
+    "params": "^0.0.5",
+    "types": "^0.0.5"
   }
 }

--- a/packages/executor/src/modules/eth.ts
+++ b/packages/executor/src/modules/eth.ts
@@ -80,7 +80,7 @@ export class Eth {
     }
     const userOpComplemented: UserOperationStruct = {
       ...userOp,
-      paymasterAndData: "0x",
+      paymasterAndData: userOp.paymasterAndData ?? "0x",
       maxFeePerGas: 0,
       maxPriorityFeePerGas: 0,
       preVerificationGas: 0,

--- a/packages/executor/src/services/BundlingService.ts
+++ b/packages/executor/src/services/BundlingService.ts
@@ -65,6 +65,7 @@ export class BundlingService {
     const wallet = this.config.getRelayer(this.network)!;
     const beneficiary = await this.selectBeneficiary();
     try {
+      const feeData = await this.provider.getFeeData();
       const txRequest = entryPointContract.interface.encodeFunctionData(
         "handleOps",
         [bundle.map((entry) => entry.userOp), beneficiary]
@@ -72,6 +73,9 @@ export class BundlingService {
       const tx = await wallet.sendTransaction({
         to: entryPoint,
         data: txRequest,
+        type: 2,
+        maxPriorityFeePerGas: feeData.maxPriorityFeePerGas ?? 0,
+        maxFeePerGas: feeData.maxFeePerGas ?? 0,
       });
 
       this.logger.debug(`Sent new bundle ${tx.hash}`);

--- a/packages/executor/src/services/UserOpValidation.ts
+++ b/packages/executor/src/services/UserOpValidation.ts
@@ -137,11 +137,11 @@ export class UserOpValidationService {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const errorResult = entryPointContract.interface.parseError(lastCall.data!);
-    const validationResult = this.parseErrorResult(userOp, {
-      errorName: errorResult.name,
-      errorArgs: errorResult.args,
-    });
+    const errorResult = await entryPointContract.callStatic
+      .simulateValidation(userOp, { gasLimit: 10e6 })
+      .catch((e: any) => e);
+    // const errorResult = entryPointContract.interface.parseError(lastCall.data!);
+    const validationResult = this.parseErrorResult(userOp, errorResult);
     const stakeInfoEntities = {
       factory: validationResult.factoryInfo,
       account: validationResult.senderInfo,

--- a/packages/params/package.json
+++ b/packages/params/package.json
@@ -1,6 +1,6 @@
 {
   "name": "params",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "Various bundler parameters",
   "author": "Etherspot",
   "homepage": "https://github.com/etherspot/skandha#readme",
@@ -21,7 +21,7 @@
     "url": "https://github.com/etherspot/skandha/issues"
   },
   "dependencies": {
-    "types": "^0.0.1"
+    "types": "^0.0.5"
   },
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "types",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "The types of Etherspot bundler client",
   "author": "Etherspot",
   "homepage": "https://https://github.com/etherspot/skandha#readme",


### PR DESCRIPTION
Previous error parsing method was failing for transactions with paymasterAndData - fixed this.

Introduced EIP-1559 (PRO-1459)


Tested against: https://github.com/eth-infinitism/bundler-spec-tests/commit/94a0634ebd6e6da657e863c134d20bc46724ed0f
With EP v0.6.0

![image](https://github.com/etherspot/skandha/assets/7760339/79ad975d-ae47-41fa-a92c-5a0a9acbcc0f)
