### PR TITLE
fix: Make Slack notify step optional

### DIFF
--- a/.github/workflows/bundler-spec-tests.yml
+++ b/.github/workflows/bundler-spec-tests.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Send Slack notification
         uses: ravsamhq/notify-slack-action@v2
         if: always()
+        continue-on-error: true
         with:
           status: ${{ job.status }}
           notification_title: "{workflow} has {status_message}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in details -->
- Make Slack notify step as optional because it fails on forked repos due to missing ENV variable ( fixes #74 )

## Types of changes
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->
-
