### PR TITLE
fix: Fix ERC4337 compliance tests CI

### DIFF
--- a/.github/workflows/bundler-spec-tests.yml
+++ b/.github/workflows/bundler-spec-tests.yml
@@ -36,13 +36,13 @@ jobs:
 
       - name: Install Geth
         run: |
-          sudo add-apt-repository -y ppa:ethereum/ethereum && \
-          sudo apt-get update && \
-          sudo apt-get install ethereum
+          wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.12.2-bed84606.tar.gz
+          tar -xvf geth-linux-amd64-1.12.2-bed84606.tar.gz
 
       - name: Run Geth
         run: |
-          geth \
+          cd geth-linux-amd64-1.12.2-bed84606 &&
+          ./geth \
           --verbosity 1 \
           --http.vhosts '*,localhost,host.docker.internal' \
           --http \
@@ -67,7 +67,8 @@ jobs:
 
       - name: Fund bundler
         run: |
-          geth \
+          cd geth-linux-amd64-1.12.2-bed84606 &&
+          ./geth \
           --exec "eth.sendTransaction({from: eth.accounts[0], to: \"0x55082761664aEb8062B3427ba5E0455bFb7b68CB\", value: web3.toWei(4337, \"ether\")})" \
           attach http://localhost:8545/
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in details -->
- Compliance tests do not work using geth 1.13.0, hence using 1.12.2

## Types of changes
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->
-
