### PR TITLE
fix: Invalid Bignumber value - eth_estimateUserOperationGas

### DIFF
--- a/packages/api/src/dto/EstimateUserOperation.dto.ts
+++ b/packages/api/src/dto/EstimateUserOperation.dto.ts
@@ -25,29 +25,23 @@ export class EstimateUserOperationStruct {
   signature!: BytesLike;
 
   @IsBigNumber()
-  @IsOptional()
-  verificationGasLimit?: BigNumberish;
+  verificationGasLimit!: BigNumberish;
 
   @IsBigNumber()
-  @IsOptional()
-  preVerificationGas?: BigNumberish;
+  preVerificationGas!: BigNumberish;
 
   @IsBigNumber()
-  @IsOptional()
-  maxFeePerGas?: BigNumberish;
+  maxFeePerGas!: BigNumberish;
 
   @IsBigNumber()
-  @IsOptional()
-  maxPriorityFeePerGas?: BigNumberish;
+  maxPriorityFeePerGas!: BigNumberish;
 
   @IsString()
   @IsCallData()
-  @IsOptional()
-  paymasterAndData?: BytesLike;
+  paymasterAndData!: BytesLike;
 
   @IsBigNumber()
-  @IsOptional()
-  callGasLimit?: BigNumberish;
+  callGasLimit!: BigNumberish;
 }
 
 export class EstimateUserOperationGasArgs {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
## Description
- Added validations for CG, VG, PVG, paymasterAndData, maxFeePerGas & maxPriorityFeePerGas using class-validators.



## Types of changes
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->

This update will throw Invalid json error, when not supplied with correct params in userop while estimating gas.
Before this change bundler was returning Bignumber undefined error when CG, VG , PVG etc was not supplied with the userOp, which made it harder to debug.

