### PR TITLE
doc: Added ws port args while testing p2p

### DIFF
--- a/docs/p2p.md
+++ b/docs/p2p.md
@@ -58,13 +58,13 @@ Example:
 ### Run a regular node
 
 ```
-./skandha node --redirectRpc --executor.bundlingMode manual --dataDir ./db --api.port 14338 --p2p.port 4338 --p2p.enrPort 4338 --p2p.bootEnrs [enr]
+./skandha node --redirectRpc --executor.bundlingMode manual --dataDir ./db --api.port 14338 --api.wsPort 14338 --p2p.port 4338 --p2p.enrPort 4338 --p2p.bootEnrs [enr]
 ```
 
 ### Run the second regular node 
 
 ```
-./skandha node --redirectRpc --executor.bundlingMode manual --dataDir ./db2 --api.port 14339 --p2p.port 4339 --p2p.enrPort 4339 --p2p.bootEnrs [enr]
+./skandha node --redirectRpc --executor.bundlingMode manual --dataDir ./db2 --api.port 14339 --api.wsPort 14339 --p2p.port 4339 --p2p.enrPort 4339 --p2p.bootEnrs [enr]
 ```
 
 ## Use Fastlane relayer


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
## Use Non-default ws Port while testing p2p bundler instances
<!--- Describe your changes in details -->
- It would make sense to use separate ws port numbers while running first and second node.
 If left to defaults it clashes with default ws port in the bootnode or any other instance for that matter.


## Types of changes
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->
-
