### PR TITLE
fix: run cmd in readme [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or follow the steps below:
 3. `cp config.json.default config.json`
 4. edit `config.json`
 5. (optional) run local geth-node from `test/geth-dev`
-6. run `./skandha`
+6. run `./skandha standalone`
 7. The bundler will be available on `http://localhost:14337/rpc/`
 
 ## 🐳 How to run (a Docker image)


### PR DESCRIPTION
Hey, team, when I'm running the service locally, using `./skandha` would encounter a non-existent optional parameters error, the log indicates there is at least one parameter. While I tried `./skandha standalone` and it works, it's also consistent with this video in readme: https://www.youtube.com/watch?v=O0_lm7b0GXE.

Thus submitting this PR to fix this, for the `develop` branch.

## Types of changes
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 
