### PR TITLE
CI: migrate workflows to setup-node v4

### DIFF
--- a/.github/workflows/bundler-spec-tests.yml
+++ b/.github/workflows/bundler-spec-tests.yml
@@ -20,7 +20,7 @@ jobs:
         run: curl -sSL https://raw.githubusercontent.com/pdm-project/pdm/main/install-pdm.py | python3 -
 
       - name: Setup NodeJS
-        uses: "actions/setup-node@v3"
+        uses: "actions/setup-node@v4"
         with:
           node-version: 18.15
 

--- a/.github/workflows/check-package-version.yml
+++ b/.github/workflows/check-package-version.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup NodeJS
-        uses: "actions/setup-node@v3"
+        uses: "actions/setup-node@v4"
         with:
           node-version: 18.15
 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup NodeJS
-        uses: "actions/setup-node@v3"
+        uses: "actions/setup-node@v4"
         with:
           node-version: 18.15
           cache: 'yarn'


### PR DESCRIPTION
Maintenance update to setup-node@v4 to align with the current best practices; nothing else modified. Refer to [v4.0.0 release notes](https://github.com/actions/setup-node/releases/tag/v4.0.0) for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to use the latest version of the Node.js setup action for improved reliability and maintenance. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->