### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/bundler-spec-tests.yml
+++ b/.github/workflows/bundler-spec-tests.yml
@@ -14,7 +14,7 @@ jobs:
   bundler-spec-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Setup PDM
         run: curl -sSL https://raw.githubusercontent.com/pdm-project/pdm/main/install-pdm.py | python3 -
@@ -25,7 +25,7 @@ jobs:
           node-version: 18.15
 
       - name: Checkout bundler spec tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: eth-infinitism/bundler-spec-tests
           # ref: f01eb0f44287b981a953a742a42bcd6a719c8812

--- a/.github/workflows/check-package-version.yml
+++ b/.github/workflows/check-package-version.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup NodeJS
         uses: "actions/setup-node@v3"

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup NodeJS
         uses: "actions/setup-node@v3"

--- a/.github/workflows/release-ep7.yml
+++ b/.github/workflows/release-ep7.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/release-ep8.yml
+++ b/.github/workflows/release-ep8.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the checkout action version used in continuous integration workflows to the latest release.
  * Improves reliability and compatibility of build and release pipelines.
  * No changes to application behavior or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->