### PR TITLE
fix: convert bytes32 y parity to single byte

### DIFF
--- a/packages/executor/src/entities/MempoolEntry.ts
+++ b/packages/executor/src/entities/MempoolEntry.ts
@@ -198,6 +198,11 @@ export class MempoolEntry implements IMempoolEntry {
       this.userOp.maxPriorityFeePerGas = BigInt(
         this.userOp.maxPriorityFeePerGas
       );
+      this.userOp.eip7702Auth = this.userOp.eip7702Auth ? {
+        ...this.userOp.eip7702Auth,
+        address: getAddress(this.userOp.eip7702Auth.address),
+        yParity: BigInt(this.userOp.eip7702Auth.yParity) === BigInt(0) ? "0x0" : "0x1",
+      } : undefined;
     } catch (err) {
       throw new RpcError("Invalid UserOp", RpcErrorCodes.INVALID_USEROP, err);
     }

--- a/packages/executor/src/services/EntryPointService/versions/0.0.8.ts
+++ b/packages/executor/src/services/EntryPointService/versions/0.0.8.ts
@@ -401,13 +401,23 @@ export class EntryPointV8Service implements IEntryPointService {
       this.simulateAndEstimateGasLimits({
         entryPoint: this.address,
         userOp,
-        stateOverride: stateOverrides,
+        stateOverride: userOp.eip7702Auth ? {
+          ...stateOverrides,
+          [userOp.sender]: {
+            code: "0xef0100" + userOp.eip7702Auth.address.substring(2),
+          },
+        }: stateOverrides,
       }),
       this.performBinarySearch({
         entryPoint: this.address,
         methodName: "binarySearchCallGas",
         targetUserOp: userOp,
-        stateOverride: stateOverrides,
+        stateOverride: userOp.eip7702Auth ? {
+          ...stateOverrides,
+          [userOp.sender]: {
+            code: "0xef0100" + userOp.eip7702Auth.address.substring(2),
+          },
+        }: stateOverrides,
         gasLimit,
       }),
     ]);

--- a/packages/executor/src/services/UserOpValidation/service.ts
+++ b/packages/executor/src/services/UserOpValidation/service.ts
@@ -175,7 +175,7 @@ export class UserOpValidationService {
         address,
         r: r,
         s: s,
-        yParity: yParity === "0x0" ? 0 : 1,
+        yParity: BigInt(yParity) === BigInt(0) ? 0 : 1,
       },
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in details -->
- Minor fix to add state overrides for type-4 tx

## Types of changes
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for EIP-7702 authorization in user operations, including automatic normalization of addresses and parity.
  - Enhanced gas simulation by conditionally applying per-sender code overrides when EIP-7702 authorization is present, improving estimate accuracy.

- Bug Fixes
  - Improved robustness of EIP-7702 parity handling by evaluating numeric values, reducing edge-case misclassification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->