### PR TITLE
fix: prevent precompiles from triggering undeployed contract errors

### DIFF
--- a/packages/executor/src/config.ts
+++ b/packages/executor/src/config.ts
@@ -59,7 +59,7 @@ export class Config {
         createWalletClient({
           transport: http(this.config.rpcEndpoint),
           account: this.accounts[0],
-          chain: this.chain
+          chain: this.chain,
         }),
       ];
     }
@@ -493,7 +493,7 @@ export class Config {
       "PRECOMPILES",
       config.precompiles || bundlerDefaultConfigs.precompiles,
       true
-    ) as string[]
+    ) as string[];
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!config.whitelistedEntities) {
@@ -591,7 +591,7 @@ const bundlerDefaultConfigs: BundlerConfig = {
   pimlicoSimulationsContract: "",
   binarySearchMaxRetries: 3,
   nativeTracer: false,
-  precompiles: []
+  precompiles: [],
 };
 
 function getEnvVar<T>(envVar: string, fallback: T): T | string {

--- a/packages/executor/src/services/UserOpValidation/validators/safe.ts
+++ b/packages/executor/src/services/UserOpValidation/validators/safe.ts
@@ -70,7 +70,7 @@ const bannedOpCodes = new Set([
   "PREVRANDAO",
   "INVALID",
   "BLOBHASH",
-  "BLOBBASEFEE"
+  "BLOBBASEFEE",
 ]);
 
 // REF: https://github.com/eth-infinitism/bundler/blob/main/packages/bundler/src/modules/ValidationManager.ts
@@ -155,7 +155,7 @@ export class SafeValidationService {
         pendingPrefunds = pendingPrefunds + BigInt(op.prefund);
       }
 
-      if (depositInfo < (pendingPrefunds + BigInt(returnInfo.prefund))) {
+      if (depositInfo < pendingPrefunds + BigInt(returnInfo.prefund)) {
         throw new RpcError(
           "Paymaster deposit too low",
           RpcErrorCodes.PAYMASTER_DEPOSIT_TOO_LOW
@@ -360,7 +360,7 @@ export class SafeValidationService {
 
       try {
         Object.keys(opcodes).forEach((opcode) => {
-          if(
+          if (
             (opcode === "BALANCE" || opcode === "SELFBALANCE") &&
             BigInt(entStakes?.stake || 0) > this.networkConfig.minStake
           ) {
@@ -442,7 +442,10 @@ export class SafeValidationService {
                 : "read from";
               throw new RpcError(
                 // eslint-disable-next-line prettier/prettier
-                `${entityTitle} has forbidden ${readWrite} ${nameAddr(addr, entityTitle)} slot ${slot}`,
+                `${entityTitle} has forbidden ${readWrite} ${nameAddr(
+                  addr,
+                  entityTitle
+                )} slot ${slot}`,
                 RpcErrorCodes.INVALID_OPCODE,
                 {
                   [entityTitle]: entStakes?.addr,
@@ -473,7 +476,8 @@ export class SafeValidationService {
         for (const addr of Object.keys(currentNumLevel.contractSize)) {
           if (
             addr !== sender &&
-            currentNumLevel.contractSize[addr].contractSize <= 2
+            currentNumLevel.contractSize[addr].contractSize <= 2 &&
+            !this.networkConfig.precompiles.includes(addr.toLowerCase())
           ) {
             const { opcode } = currentNumLevel.contractSize[addr];
             throw new RpcError(
@@ -645,8 +649,9 @@ export class SafeValidationService {
       try {
         Object.keys(opcodes).forEach((opcode) => {
           if (bannedOpCodes.has(EVM_OPCODES[opcode])) {
-            if(
-              (EVM_OPCODES[opcode] === "BALANCE" || EVM_OPCODES[opcode] === "SELFBALANCE") &&
+            if (
+              (EVM_OPCODES[opcode] === "BALANCE" ||
+                EVM_OPCODES[opcode] === "SELFBALANCE") &&
               BigInt(entStakes?.stake || 0) > this.networkConfig.minStake
             ) {
               return;
@@ -682,7 +687,10 @@ export class SafeValidationService {
           }
         }
 
-        for (const [addr, { reads, writes, transientReads, transientWrites }] of Object.entries(access)) {
+        for (const [
+          addr,
+          { reads, writes, transientReads, transientWrites },
+        ] of Object.entries(access)) {
           if (addr === sender) {
             continue;
           }
@@ -708,7 +716,7 @@ export class SafeValidationService {
             ...Object.keys(writes),
             ...Object.keys(reads),
             ...Object.keys(transientReads),
-            ...Object.keys(transientWrites)
+            ...Object.keys(transientWrites),
           ]) {
             if (isSlotAssociatedWith(slot, sender, entitySlots)) {
               if (userOp.factory) {
@@ -731,7 +739,10 @@ export class SafeValidationService {
                 : "read from";
               throw new RpcError(
                 // eslint-disable-next-line prettier/prettier
-                `${entityTitle} has forbidden ${readWrite} ${nameAddr(addr, entityTitle)} slot ${slot}`,
+                `${entityTitle} has forbidden ${readWrite} ${nameAddr(
+                  addr,
+                  entityTitle
+                )} slot ${slot}`,
                 RpcErrorCodes.INVALID_OPCODE,
                 {
                   [entityTitle]: entStakes?.addr,
@@ -759,12 +770,12 @@ export class SafeValidationService {
           }
         }
 
-        const contractSizes = getContractSizes(currentNumLevel,  {});
+        const contractSizes = getContractSizes(currentNumLevel, {});
         for (const addr of Object.keys(contractSizes)) {
           if (
             addr !== sender &&
             contractSizes[addr].contractSize <= 2 &&
-            !this.networkConfig.precompiles.includes(addr)
+            !this.networkConfig.precompiles.includes(addr.toLowerCase())
           ) {
             const { opcode } = contractSizes[addr];
             throw new RpcError(


### PR DESCRIPTION
This PR fixes an issue where precompiled contracts were incorrectly flagged as undeployed contracts during user operation validation.
  
The fix adds a check to exclude precompiled addresses from the contract size validation. This is applied to both
the JavaScript tracer path (line 479) and the native tracer path (line 777) to ensure consistent behavior
regardless of which tracer is configured. Addresses are normalized to lowercase for reliable comparison with the
precompiles list from the network configuration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents false “undeployed contract” errors by exempting precompiled addresses during validation.
  - Normalizes address comparisons (case-insensitive) to avoid mismatches across networks.

- Improvements
  - Clearer validation errors with human-readable opcode names instead of numeric codes.

- Chores
  - Formatting-only updates to configuration files; no behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->