### PR TITLE
fix: trim leading zeroes

### DIFF
--- a/packages/executor/src/services/BundlingService/utils/eip7702.ts
+++ b/packages/executor/src/services/BundlingService/utils/eip7702.ts
@@ -1,6 +1,7 @@
 import {
   Authorization,
   AuthorizationList,
+  Hex,
   RpcAuthorization,
   RpcAuthorizationList,
   toHex,
@@ -17,20 +18,24 @@ export function getAuthorizationList(bundle: Bundle): {
     const { userOp } = entry;
     if (!userOp.eip7702Auth) continue;
     const { address, chainId, nonce, r, s, yParity } = userOp.eip7702Auth;
+    // Remove leading zeroes from r and s values
+    const rTrimmed: Hex = r.startsWith('0x') ? `0x${BigInt(r).toString(16)}` : r;
+    const sTrimmed: Hex = s.startsWith('0x') ? `0x${BigInt(s).toString(16)}` : s;
+    
     const rpcAuthorization: RpcAuthorization = {
       address,
       chainId: toHex(BigInt(chainId)),
       nonce: toHex(BigInt(nonce)),
-      r,
-      s,
+      r: rTrimmed,
+      s: sTrimmed,
       yParity,
     };
     const authorization: Authorization = {
       address: address as `0x${string}`,
       chainId: Number(BigInt(chainId)),
       nonce: Number(BigInt(nonce)),
-      r,
-      s,
+      r: rTrimmed,
+      s: sTrimmed,
       yParity: yParity === "0x0" ? 0 : 1,
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in details -->
- trim leading zeroes for `r` and `s` values.

## Types of changes
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Normalized authorization signatures by trimming leading zeros in signature values, improving compatibility with EIP-7702 flows.
  - Reduces the likelihood of rejected requests or failed bundling due to inconsistently formatted signatures across providers and networks.
  - Enhances reliability when processing authorizations, resulting in fewer edge-case errors for users interacting with compliant wallets and nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->