### PR TITLE
fix: freeze bun version on dockerfile to 1.2.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-amd64} oven/bun:1-alpine AS build_src
+FROM --platform=${BUILDPLATFORM:-amd64} oven/bun:1.2.23-alpine AS build_src
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache g++ make python3 git py3-setuptools && rm -rf /var/cache/apk/*
 
@@ -10,7 +10,7 @@ RUN bun install --frozen-lockfile && \
 
 RUN cd node_modules/bcrypto && bun install
 
-FROM oven/bun:1-alpine
+FROM oven/bun:1.2.23-alpine
 WORKDIR /usr/app
 COPY --from=build_src /usr/app .
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in details -->
- use v1.2.23 bun version

## Types of changes
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded container runtime to Bun 1.2.23, improving stability and performance.
  * Container now launches the CLI by default via an entrypoint, simplifying usage in deployments and local runs (no need to specify the command) and ensuring consistent startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->