### PR TITLE
feat: release v4 to dockerhub

### DIFF
--- a/.github/workflows/release-ep9.yml
+++ b/.github/workflows/release-ep9.yml
@@ -1,0 +1,45 @@
+name: Build skandha v4 docker image
+
+on:
+    push:
+        branches:
+            - "release-v9"
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Login to Docker Hub
+              uses: docker/login-action@v2
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+            - name: Get package version
+              id: get_version
+              run: echo version=$(node -p "require('./package.json').version") >> $GITHUB_OUTPUT
+            - name: Build and push
+              uses: docker/build-push-action@v4
+              with:
+                  context: .
+                  platforms: linux/amd64,linux/arm64
+                  file: ./Dockerfile
+                  push: true
+                  tags: |
+                      ${{ secrets.DOCKERHUB_USERNAME }}/skandha:v4-${{ steps.get_version.outputs.version }}
+                      ${{ secrets.DOCKERHUB_USERNAME }}/skandha:v4-latest
+            - name: Create GitHub release
+              uses: "marvinpinto/action-automatic-releases@6273874b61ebc8c71f1a61b2d98e234cf389b303"
+              with:
+                  repo_token: "${{ secrets.GITHUB_TOKEN }}"
+                  automatic_release_tag: v4-${{ steps.get_version.outputs.version }}
+                  prerelease: false
+                  title: Release v4-${{ steps.get_version.outputs.version }}
+            - name: Trigger pipeline
+              run: ${{ secrets.PIPELINE_TRIGGER  }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building, tagging, and releasing the `skandha` v4 Docker image whenever code is pushed to the `release-v9` branch. The workflow also handles Docker Hub authentication, multi-platform builds, GitHub release creation, and triggers an external pipeline.

**Release automation and CI/CD enhancements:**

* Added `.github/workflows/release-ep9.yml` workflow to build and push `skandha` v4 Docker images for both `amd64` and `arm64` platforms on pushes to the `release-v9` branch.
* Integrated Docker Hub login and automated version tagging using the package version from `package.json`.
* Automated GitHub release creation with versioned tags and titles, ensuring releases are published for each new image build.
* Included a step to trigger an external pipeline after successful build and release.