### PR TITLE
fix: validate user operation hash before lookup

### DIFF
--- a/packages/executor/src/modules/eth.ts
+++ b/packages/executor/src/modules/eth.ts
@@ -19,7 +19,7 @@ import { UserOperation } from "@skandha/types/lib/contracts/UserOperation";
 import { UserOperationStruct } from "@skandha/types/lib/contracts/EPv6/EntryPoint.js";
 import { MempoolEntryStatus } from "@skandha/types/lib/executor";
 import { BlockscoutAPI } from "@skandha/utils/lib/third-party";
-import { PublicClient, Hex, GetTransactionReturnType } from "viem";
+import { PublicClient, Hex, GetTransactionReturnType, isHex } from "viem";
 import {
   UserOpValidationService,
   MempoolService,
@@ -676,6 +676,12 @@ export class Eth {
   async getUserOperationByHash(
     hash: string
   ): Promise<UserOperationByHashResponse | null> {
+    if (!isHex(hash, { strict: true }) || hash.length !== 66) {
+      throw new RpcError(
+        "Missing/invalid userOpHash",
+        RpcErrorCodes.INVALID_USEROP
+      );
+    }
     const entry = await this.mempoolService.getEntryByHash(hash);
     if (entry) {
       if (entry.status < MempoolEntryStatus.Submitted || entry.transaction) {


### PR DESCRIPTION
Validates `eth_getUserOperationByHash` input before checking the mempool or chain logs.

Missing, non-hex, or non-`bytes32` hashes now return the existing `INVALID_USEROP` error instead of being passed through to lookup code.

Validation:
- `git diff --check`
- `npm run lint -- --quiet packages/executor/src/modules/eth.ts` blocked by an existing `eslint-plugin-prettier` / Prettier API mismatch: `prettier.resolveConfig.sync is not a function`
- `npx tsc -p packages/executor/tsconfig.build.json --noEmit` blocked because workspace packages such as `@skandha/types/lib/...` and `@skandha/params/lib/...` are not built in this checkout